### PR TITLE
eslint-config-prettier updates

### DIFF
--- a/packages/eslint-config-imaginelearning/base.js
+++ b/packages/eslint-config-imaginelearning/base.js
@@ -123,7 +123,10 @@ module.exports = {
 		'no-restricted-syntax': ['error', 'WithStatement'],
 
 		// Enforce Prettier's formatting rules.
-		'prettier/prettier': 'warn',
+		'prettier/prettier': ['warn', {
+			// Don't warn for OS-specific line endings. Git should handle this anyway.
+			endOfLine: 'auto',
+		}],
 
 		// Don't require a space before a comment when designating a comment block with:
 		//====

--- a/packages/eslint-config-imaginelearning/package.json
+++ b/packages/eslint-config-imaginelearning/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@imaginelearning/eslint-config",
-	"version": "0.1.2",
+	"version": "1.0.0",
 	"description": "ESLint configuration used by Imagine Learning",
 	"main": "index.js",
 	"repository": {
@@ -23,7 +23,7 @@
 		"babel-eslint": ">=10",
 		"eslint": ">=7",
 		"eslint-config-airbnb": ">=18",
-		"eslint-config-prettier": ">= 7 < 8",
+		"eslint-config-prettier": ">=8",
 		"eslint-config-react-app": ">=6",
 		"eslint-plugin-flowtype": ">=5",
 		"eslint-plugin-import": ">=2",

--- a/packages/eslint-config-imaginelearning/react.js
+++ b/packages/eslint-config-imaginelearning/react.js
@@ -3,7 +3,7 @@ module.exports = {
 	parserOptions: {
 		project: './tsconfig.json',
 	},
-	extends: ['airbnb/hooks', 'react-app', 'plugin:jsx-a11y/recommended', 'prettier/react'],
+	extends: ['airbnb/hooks', 'react-app', 'plugin:jsx-a11y/recommended', 'prettier'],
 	plugins: ['@typescript-eslint', 'jsx-a11y', 'prettier'],
 	rules: {
 		// Enforce consistent naming conventions.


### PR DESCRIPTION
- Updated to use newer version of `eslint-config-prettier` and fixed config to accommodate breaking changes.
- Changed `prettier/prettier` rule to allow *Nix and Windows line endings.