### PR TITLE
Fix naming-convention rule for React component props

### DIFF
--- a/packages/eslint-config-imaginelearning/package.json
+++ b/packages/eslint-config-imaginelearning/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@imaginelearning/eslint-config",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "ESLint configuration used by Imagine Learning",
 	"main": "index.js",
 	"repository": {

--- a/packages/eslint-config-imaginelearning/react.js
+++ b/packages/eslint-config-imaginelearning/react.js
@@ -27,7 +27,10 @@ module.exports = {
 			},
 			{
 				selector: ['objectLiteralProperty', 'parameter', 'typeProperty'],
-				filter: 'Component',
+				filter: {
+					regex: 'Component$',
+					match: true,
+				},
 				format: ['PascalCase'],
 			},
 			// Allow `__html` for using `dangerouslySetInnerHTML` in React


### PR DESCRIPTION
The rule is intended to capture React props that reference a component, for example:
```ts
interface MyComponentProps {
    NestedComponent: React.ComponentType<NestedComponentProps>;
    // ...
}
```
But should not capture other props that use the word "Component" in them, for example:
```ts
interface MyComponentProps {
    requiredComponents: string[];
    // ...
}
```

These changes update the rule to use a regex to identify props that end with `Component`, which is _hopefully_ more accurate.